### PR TITLE
Select drawlayers only feature

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -93,7 +93,8 @@ const format = new GeoJSON({ featureProjection: "EPSG:3857" });
 const ModifyPolygon = {
   init: function(e) {
     this.select = new Select({
-      style: selectedPolygonStyles
+      style: selectedPolygonStyles,
+      layers: [drawingLayer, savedPolygonsLayer]
     });
     map.addInteraction(this.select);
 

--- a/src/main.js
+++ b/src/main.js
@@ -191,6 +191,7 @@ DrawPolygon.init();
 const DeletePolygon = {
   init: function() {
     this.deleteSelect = new Select({
+      layers: [drawingLayer, savedPolygonsLayer],
       style: new Style({
         stroke: new Stroke({
           color: "#F89911",


### PR DESCRIPTION
Issue: the user could select features from both the base map layers (GeoJSON polygon and lines) and drawing layers.
This has now been resolved. The user can only select features (for modification and deletion) which they have drawn. 